### PR TITLE
Using HTTPS URL to clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When you run a function, the executed command is displayed and that helps you me
 ### Installation in 2 Simple Steps
 
 1- Download command line tool to your local machine:
-> `git clone git@github.com:guarinogabriel/mac-cli.git && cd mac-cli`
+> `git clone https://github.com/guarinogabriel/mac-cli.git && cd mac-cli`
 
 2- Run the installer. There are 2 install options:
 


### PR DESCRIPTION
I faced this.
![screen shot 2016-06-26 at 7 25 14 pm](https://cloud.githubusercontent.com/assets/3911469/16361997/76a01f4a-3bd4-11e6-9043-a1f81fcf7221.png)

Please check out this, Cloning with HTTPS is a way recommended by Github.
https://help.github.com/articles/which-remote-url-should-i-use/

Thanks for the nice work 👍 