### PR TITLE
Updated macOS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mac CLI
 
- OS X command line tools for developers
+ macOS command line tools for developers
 
 ![image](https://github.com/guarinogabriel/mac-cli/raw/master/demo/demo.gif)
 


### PR DESCRIPTION
As apple presented on WWDC, OS X is now macOS