### PR TITLE
Fix pip and Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ These are the requirements to be able to run all the commands (all the dependenc
 
 * Homebrew
 * GIT
-* PyPA (pip)
-* Pipe Viewer (pv)
 * Python
+* pip (Python package manager)
+* Pipe Viewer (pv)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Update the shell script to match your local environment configuration. Global va
 These are the requirements to be able to run all the commands (all the dependencies/requirements can be installed running "mac install"):
 
 * Homebrew
-* GIT
+* Git
 * Python
 * pip (Python package manager)
 * Pipe Viewer (pv)
@@ -52,7 +52,7 @@ The following amazing projects have been integrated on the mac script (all the i
 * speedtest-cli (https://github.com/sivel/speedtest-cli)
 * n98-magerun (https://github.com/netz98/n98-magerun)
 * n98-magerun2 (https://github.com/netz98/n98-magerun2)
-* GIT-stats (https://github.com/IonicaBizau/git-stats)
+* Git Stats (https://github.com/IonicaBizau/git-stats)
 * Storm (https://github.com/emre/storm)
 
 ---
@@ -69,7 +69,7 @@ The following amazing projects have been integrated on the mac script (all the i
 | `mac list:ssh`  | List all SSH commands in mac script  | |
 | `mac list:performance`  | List all performance commands in mac script  | |
 | `mac list:terminal`  | List all terminal commands in mac script  | |
-| `mac list:git`  | List all GIT commands in mac script  | |
+| `mac list:git`  | List all Git commands in mac script  | |
 | `mac list:web`  | List all Web commands in mac script  | |
 | `mac list:brew`  | List all Homebrew commands in mac script  | |
 | `mac list:xcode`  | List all Xcode commands in mac script  | |
@@ -216,7 +216,7 @@ The following amazing projects have been integrated on the mac script (all the i
 | `mac iterm:tab-title`  | Set title of current iTerm tab  |
 
 
-### GIT Utilities
+### Git Utilities
 
 | Command  | Description |
 | ------------- | ------------- |
@@ -227,14 +227,14 @@ The following amazing projects have been integrated on the mac script (all the i
 | `mac git:undo-commit`  | Undo latest commit  |
 | `mac git:log`  | See latest commits IDs and titles for current branch  |
 | `mac git:branch`  | See all branches  |
-| `mac git:branch:rename`  | Rename GIT branch |
-| `mac git:branch:remove-local`  | Remove local GIT branch |
-| `mac git:branch:remove-remote`  | Remove local and remote GIT branch |
-| `mac git:remove`  | Remove GIT from current project  |
-| `mac git:settings`  | Check GIT settings  |
+| `mac git:branch:rename`  | Rename Git branch |
+| `mac git:branch:remove-local`  | Remove local Git branch |
+| `mac git:branch:remove-remote`  | Remove local and remote Git branch |
+| `mac git:remove`  | Remove Git from current project  |
+| `mac git:settings`  | Check Git settings  |
 | `mac git:add-removed`  | Add removed files to staged files  |
-| `mac git:size`  | Get size for current GIT directory  |
-| `mac github:streak`  | See current GIT contribution streak |
+| `mac git:size`  | Get size for current Git directory  |
+| `mac github:streak`  | See current Git contribution streak |
 
 # Web Utilities
 

--- a/mac
+++ b/mac
@@ -541,8 +541,12 @@ elif [ "$function" == "install" ]; then
 	printf "${GREEN}/usr/bin/ruby -e '\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)'\n${NC}"
 	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 	echo "Installing pip..."
-	printf "${GREEN}sudo easy_install pip\n${NC}"
-	sudo easy_install pip
+	printf "${GREEN}curl https://bootstrap.pypa.io/get-pip.py > get-pip.py\n${NC}"
+	curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
+	printf "${GREEN}sudo python get-pip.py\n${NC}"
+	sudo python get-pip.py
+	# Clean up (unannounced)
+	rm get-pip.py
 	echo "Installing Git..."
 	printf "${GREEN}brew install git\n${NC}"
 	brew install git

--- a/mac
+++ b/mac
@@ -171,7 +171,7 @@ if [[ "$function" == "list" || "$function" == "help" ]]; then
     printf "${LIGHTBLUE}mac iterm:tab-title${GRAY}: Set title to current iTerm tab \n"
 
 
-    printf "\n\n${WHITEBOLD}GIT Utilities: \n"
+    printf "\n\n${WHITEBOLD}Git Utilities: \n"
     printf "${LIGHTBLUE}mac git:config${GRAY}: Display local Git configuration \n"
     printf "${LIGHTBLUE}mac git:open${GRAY}: Open current repository on Github \n"
     printf "${LIGHTBLUE}mac git:create:branch${GRAY}: Create branch based on current branch \n"
@@ -179,14 +179,14 @@ if [[ "$function" == "list" || "$function" == "help" ]]; then
     printf "${LIGHTBLUE}mac git:undo-commit${GRAY}: Undo latest commit \n"
     printf "${LIGHTBLUE}mac git:log${GRAY}: See latest commits IDs and titles for current branch \n"
     printf "${LIGHTBLUE}mac git:branch${GRAY}: See all branches \n"
-    printf "${LIGHTBLUE}mac git:branch:rename${GRAY}: Rename GIT branch \n"
-    printf "${LIGHTBLUE}mac git:branch:remove-local${GRAY}: Remove local GIT branch \n"
-    printf "${LIGHTBLUE}mac git:branch:remove-remote${GRAY}: Remove local and remote GIT branch \n"
-    printf "${LIGHTBLUE}mac git:removeprintf "${LIGHTBLUE}mac git:branch${GRAY}: See all branches \n"${GRAY}: Remove GIT from current project \n"
-    printf "${LIGHTBLUE}mac git:settings${GRAY}: Check GIT settings \n"
+    printf "${LIGHTBLUE}mac git:branch:rename${GRAY}: Rename Git branch \n"
+    printf "${LIGHTBLUE}mac git:branch:remove-local${GRAY}: Remove local Git branch \n"
+    printf "${LIGHTBLUE}mac git:branch:remove-remote${GRAY}: Remove local and remote Git branch \n"
+    printf "${LIGHTBLUE}mac git:removeprintf "${LIGHTBLUE}mac git:branch${GRAY}: See all branches \n"${GRAY}: Remove Git from current project \n"
+    printf "${LIGHTBLUE}mac git:settings${GRAY}: Check Git settings \n"
     printf "${LIGHTBLUE}mac git:add-removed${GRAY}: Add removed files to staged files \n"
-    printf "${LIGHTBLUE}mac git:size${GRAY}: Get size for current GIT repository \n"
-    printf "${LIGHTBLUE}mac github:streak${GRAY}: See current GIT contribution streak \n"
+    printf "${LIGHTBLUE}mac git:size${GRAY}: Get size for current Git repository \n"
+    printf "${LIGHTBLUE}mac github:streak${GRAY}: See current Git contribution streak \n"
 
 
     printf "\n\n${WHITEBOLD}Web Utilities: \n"
@@ -375,7 +375,7 @@ elif [ "$function" == "list:terminal" ]; then
     printf "${LIGHTBLUE}mac iterm:tab-title${GRAY}: Set title to current iTerm tab \n"
 
 #--------------------------------------------------------------------
-# mac script commands list - GIT commands
+# mac script commands list - Git commands
 #--------------------------------------------------------------------
 
 elif [ "$function" == "list:git" ]; then
@@ -383,7 +383,7 @@ elif [ "$function" == "list:git" ]; then
     printf "\n${WHITEBOLD} mac – automation tools for OS X\n"
     printf "${WHITEBOLD}==================================="
 
-    printf "\n\n${WHITEBOLD}GIT Utilities: \n"
+    printf "\n\n${WHITEBOLD}Git Utilities: \n"
     printf "${LIGHTBLUE}mac git:config${GRAY}: Display local Git configuration \n"
     printf "${LIGHTBLUE}mac git:open${GRAY}: Open current repository on Github \n"
     printf "${LIGHTBLUE}mac git:create:branch${GRAY}: Create branch based on current branch \n"
@@ -391,14 +391,14 @@ elif [ "$function" == "list:git" ]; then
     printf "${LIGHTBLUE}mac git:undo-commit${GRAY}: Undo latest commit \n"
     printf "${LIGHTBLUE}mac git:log${GRAY}: See latest commits IDs and titles for current branch \n"
     printf "${LIGHTBLUE}mac git:branch${GRAY}: See all branches \n"
-    printf "${LIGHTBLUE}mac git:branch:rename${GRAY}: Rename GIT branch \n"
-    printf "${LIGHTBLUE}mac git:branch:remove-local${GRAY}: Remove local GIT branch \n"
-    printf "${LIGHTBLUE}mac git:branch:remove-remote${GRAY}: Remove local and remote GIT branch \n"
-    printf "${LIGHTBLUE}mac git:remove${GRAY}: Remove GIT from current project \n"
-    printf "${LIGHTBLUE}mac git:settings${GRAY}: Check GIT settings \n"
+    printf "${LIGHTBLUE}mac git:branch:rename${GRAY}: Rename Git branch \n"
+    printf "${LIGHTBLUE}mac git:branch:remove-local${GRAY}: Remove local Git branch \n"
+    printf "${LIGHTBLUE}mac git:branch:remove-remote${GRAY}: Remove local and remote Git branch \n"
+    printf "${LIGHTBLUE}mac git:remove${GRAY}: Remove Git from current project \n"
+    printf "${LIGHTBLUE}mac git:settings${GRAY}: Check Git settings \n"
     printf "${LIGHTBLUE}mac git:add-removed${GRAY}: Add removed files to staged files \n"
-    printf "${LIGHTBLUE}mac git:size${GRAY}: Get size for current GIT repository \n"
-    printf "${LIGHTBLUE}mac github:streak${GRAY}: See current GIT contribution streak \n"
+    printf "${LIGHTBLUE}mac git:size${GRAY}: Get size for current Git repository \n"
+    printf "${LIGHTBLUE}mac github:streak${GRAY}: See current Git contribution streak \n"
 
 
 #--------------------------------------------------------------------
@@ -543,7 +543,7 @@ elif [ "$function" == "install" ]; then
 	echo "Installing pip..."
 	printf "${GREEN}sudo easy_install pip\n${NC}"
 	sudo easy_install pip
-	echo "Installing GIT..."
+	echo "Installing Git..."
 	printf "${GREEN}brew install git\n${NC}"
 	brew install git
 	echo "Installing pv (Pipe Viewer)..."
@@ -566,7 +566,7 @@ elif [ "$function" == "install:all" ]; then
 	echo "Installing pip..."
 	printf "${GREEN}sudo easy_install pip\n${NC}"
 	sudo easy_install pip
-	echo "Installing GIT..."
+	echo "Installing Git..."
 	printf "${GREEN}brew install git\n${NC}"
 	brew install git
 	echo "Installing pv (Pipe Viewer)..."
@@ -607,7 +607,7 @@ elif [ "$function" == "install:all" ]; then
 	curl -sS https://getcomposer.org/installer | php
 	printf "${GREEN}sudo mv composer.phar /usr/local/bin/\n${NC}"
 	sudo mv composer.phar /usr/local/bin/
-	echo "Installing GIT cal (https://github.com/k4rthik/git-cal)..."
+	echo "Installing Git cal (https://github.com/k4rthik/git-cal)..."
 	printf "${GREEN}brew install git-cal\n${NC}"
 	brew install git-cal
 	echo "Installing ImageOptim..."
@@ -1461,7 +1461,7 @@ elif [ "$function" == "iterm:tab-title" ]; then
 	echo "Tab title updated"
 
 #--------------------------------------------------------------------
-# GIT Utilities
+# Git Utilities
 #--------------------------------------------------------------------
 
 # Display local Git configuration
@@ -1485,7 +1485,7 @@ elif [ "$function" == "git:open" ]; then
       giturl=$giturl
       open $giturl
 
-# Create GIT branch based on current branch
+# Create Git branch based on current branch
 elif [ "$function" == "git:create:branch" ]; then
 
     if [ ! -z "$firstParameter" -a "$firstParameter" != " " ]; then
@@ -1514,7 +1514,7 @@ elif [ "$function" == "git:log" ]; then
 elif [ "$function" == "git:branch" ]; then
 	git branch -a
 
-# Rename GIT branch
+# Rename Git branch
 elif [ "$function" == "git:branch:rename" ]; then
 
 	 if [ ! -z "$firstParameter" -a "$firstParameter" != " " ]; then
@@ -1526,7 +1526,7 @@ elif [ "$function" == "git:branch:rename" ]; then
         echo "E.g.: git:branch:rename sample-branch"
     fi
 
-# Remove local GIT branch
+# Remove local Git branch
 elif [ "$function" == "git:branch:remove-local" ]; then
 
 	 if [ ! -z "$firstParameter" -a "$firstParameter" != " " ]; then
@@ -1538,7 +1538,7 @@ elif [ "$function" == "git:branch:remove-local" ]; then
         echo "E.g.: git:branch:remove-local sample-branch"
     fi
 
-# Remove local and remote GIT branch
+# Remove local and remote Git branch
 elif [ "$function" == "git:branch:remove-remote" ]; then
 
 	 if [ ! -z "$firstParameter" -a "$firstParameter" != " " ]; then
@@ -1552,7 +1552,7 @@ elif [ "$function" == "git:branch:remove-remote" ]; then
         echo "E.g.: git:branch:remove-remote sample-branch"
     fi
 	
-# Check GIT settings
+# Check Git settings
 elif [ "$function" == "git:settings" ]; then
 	git config --list
 	
@@ -1560,28 +1560,28 @@ elif [ "$function" == "git:settings" ]; then
 elif [ "$function" == "git:add-removed" ]; then
 	git add -u
 	
-# Remove GIT from current project
+# Remove Git from current project
 elif [ "$function" == "git:remove" ]; then
 	find . -name '.git' -exec rm -rf {} \;
 
-# Open current GIT repository URL
+# Open current Git repository URL
 elif [ "$function" == "git:open" ]; then
 	open `git remote -v | awk '/fetch/{print $2}' | sed -Ee 's#(git@|git://)#http://#' -e 's@com:@com/@'`| head -n1
 
-# Get size of current GIT repository
+# Get size of current Git repository
 elif [ "$function" == "git:size" ]; then
 	git bundle create tmp.bundle --all
-	printf "\n\nCurrent GIT repository size: \n"
+	printf "\n\nCurrent Git repository size: \n"
 	du -sh tmp.bundle
 	rm tmp.bundle
 
-# See current GIT contribution streak
+# See current Git contribution streak
 elif [ "$function" == "github:streak" ]; then
 
 	if [ -d .git ]; then
 	    git-cal --author=$github_username
 	else
-	    echo "Error: The current directory is not a GIT repository"
+	    echo "Error: The current directory is not a Git repository"
 	fi
 
 #--------------------------------------------------------------------

--- a/mac
+++ b/mac
@@ -564,8 +564,12 @@ elif [ "$function" == "install:all" ]; then
 	printf "${GREEN}/usr/bin/ruby -e '\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)'\n${NC}"
 	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 	echo "Installing pip..."
-	printf "${GREEN}sudo easy_install pip\n${NC}"
-	sudo easy_install pip
+	printf "${GREEN}curl https://bootstrap.pypa.io/get-pip.py > get-pip.py\n${NC}"
+	curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
+	printf "${GREEN}sudo python get-pip.py\n${NC}"
+	sudo python get-pip.py
+	# Clean up (unannounced)
+	rm get-pip.py
 	echo "Installing Git..."
 	printf "${GREEN}brew install git\n${NC}"
 	brew install git


### PR DESCRIPTION
1. Fix pip naming (PyPA is the organization behind pip)
2. Fix GIT → Git spelling (that’s the official way to spell it)
3. Install pip using `get-pip.py` instead of deprecated `easy_install`

Keep up the good work!

(PS. might be nice to clean up indentation and trailing whitespace in the script)