### PR TITLE
add toggle functionality to mac:time

### DIFF
--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -32,7 +32,12 @@ elif [ "$fn" == "time" ]; then
 	if [ "$echocommand" == "true" ]; then
 	    echo "${GREEN}while sleep 1;do tput sc;tput cup 0 $(($(tput cols)-29));date;tput rc;done &'\n\n${NC}"
 	fi
-	while sleep 1;do tput sc;tput cup 0 $(($(tput cols)-29));date;tput rc;done &
+    if [ -z "$(pgrep macClock)"   ]; then
+        # naming the process
+        ( exec -a macClock bash -c 'while sleep 1;do tput sc;tput cup 0 $(($(tput cols)-29));date;tput rc;done' &   )
+    else
+        pkill macClock
+    fi
 
 # Remove files older than X days in current folder
 elif [ "$fn" == "files:remove-older" ]; then


### PR DESCRIPTION
I gave a name to the process, so We can kill the process by its name if it is running.

```
 #  ps -o pid,command |  grep -i macClock                                                                                                 
48997 macClock -c while sleep 1;do tput sc;tput cup 0 $(($(tput cols)-29));date;tput rc;done
```
```
# pkill macClock
```

I've added a toggle functionality, if we run mac time it should or not show the time in the console depends if it's running, if it's running it should kill the process to stop it and if it's not running then it should show the clock
