### PR TITLE
Bash completion

### DIFF
--- a/mac
+++ b/mac
@@ -193,6 +193,7 @@ COMMANDS=(
     magento:url-rewrites:disable
     magento2:install
 )
+## ---- END OF COMMANDS; Comment required for bash_completion------
 
 if [[ ! " ${COMMANDS[@]} " =~ " ${fn} " ]]; then
     echo "${RED}Command not found: ${NC}"

--- a/mac-cli/misc/bash_completion
+++ b/mac-cli/misc/bash_completion
@@ -5,11 +5,13 @@ _mac() {
     local MACWORDS cur
 
     COMPREPLY=()
-    _get_comp_words_by_ref cur
+    _get_comp_words_by_ref -n : cur
 
     MACWORDS=$(awk "/COMMANDS=/,/#/" < /usr/local/bin/mac  | tail -n +2 | sed '/)/d;/#/d')
 
     COMPREPLY=( $( compgen -W "$MACWORDS" -- "$cur" ) )
+
+    __ltrim_colon_completions "$cur"
 }
 complete -F _mac mac
 }

--- a/mac-cli/misc/bash_completion
+++ b/mac-cli/misc/bash_completion
@@ -1,0 +1,16 @@
+# Mac_CLI bash completion
+
+have mac && {
+_mac() {
+    local MACWORDS cur
+
+    COMPREPLY=()
+    _get_comp_words_by_ref cur
+
+    MACWORDS=$(awk "/COMMANDS=/,/#/" < /usr/local/bin/mac  | tail -n +2 | sed '/)/d;/#/d')
+
+    COMPREPLY=( $( compgen -W "$MACWORDS" -- "$cur" ) )
+}
+complete -F _mac mac
+}
+

--- a/mac-cli/tools/install
+++ b/mac-cli/tools/install
@@ -264,6 +264,22 @@ main() {
         printf "${NC}"
     fi
 
+    if ! brew list | grep -q bash-completion ; then 
+	    echo "Installing bash-completion"
+	    echo "${GREEN}brew install bash-completion\n\n${NC}"
+	    brew install bash-completion
+	    echo 'if [ -f $(brew --prefix)/etc/bash_completion ]; then source $(brew --prefix)/etc/bash_completion; fi' >> ~/.bash_profile
+	    echo "Setting up Mac-CLI bash-completion"
+	    if [ -d /usr/local/etc/bash_completion.d/ ]; then
+	    	cp /usr/local/bin/mac-cli/misc/bash_completion /usr/local/etc/bash_completion.d/mac
+	    fi
+    else
+	    echo "Setting up Mac-CLI bash-completion"
+	    if [ -d $(brew --prefix)/etc/bash_completion.d/ ]; then
+		    cp /usr/local/bin/mac-cli/misc/bash_completion $(brew --prefix)/etc/bash_completion.d/mac
+	    fi
+    fi
+
 }
 
 main

--- a/mac-cli/tools/install
+++ b/mac-cli/tools/install
@@ -268,7 +268,7 @@ main() {
 	    echo "Installing bash-completion"
 	    echo "${GREEN}brew install bash-completion\n\n${NC}"
 	    brew install bash-completion
-	    echo 'if [ -f $(brew --prefix)/etc/bash_completion ]; then source $(brew --prefix)/etc/bash_completion; fi' >> ~/.bash_profile
+	    echo 'if [ -f $(brew --prefix)/etc/bash_completion ]; then source $(brew --prefix)/etc/bash_completion; fi' >> ~/.bashrc
 	    echo "Setting up Mac-CLI bash-completion"
 	    if [ -d /usr/local/etc/bash_completion.d/ ]; then
 	    	cp /usr/local/bin/mac-cli/misc/bash_completion /usr/local/etc/bash_completion.d/mac
@@ -277,6 +277,7 @@ main() {
 	    echo "Setting up Mac-CLI bash-completion"
 	    if [ -d $(brew --prefix)/etc/bash_completion.d/ ]; then
 		    cp /usr/local/bin/mac-cli/misc/bash_completion $(brew --prefix)/etc/bash_completion.d/mac
+		    echo 'if [ -f $(brew --prefix)/etc/bash_completion ]; then source $(brew --prefix)/etc/bash_completion; fi' >> ~/.bashrc
 	    fi
     fi
 


### PR DESCRIPTION
Bash completion for Mac-CLI

* Install script will now check for "brew bash-completion" if exists  it just copies bash_completion file from mac-cli/misc directory to brew's bash-completion directory `(brew --prefix)/etc/bash_completion.d/` as _mac_ (filename).
* If "brew bash-completion" isn't there, install script will install bash-completion `brew install bash-completion` and updates bash_profile.
* _bash_completion_ will auto generate suggestions from **COMMANDS** array in main mac script.