### PR TITLE
Changed default command to 'list' to prevent the unhelpful empty command not found error

### DIFF
--- a/mac
+++ b/mac
@@ -190,13 +190,18 @@ COMMANDS=(
 )
 ## ---- END OF COMMANDS; Comment required for bash_completion------
 
+if [ -z "$fn" ]; then
+    fn="list"
+fi
+
 if [[ ! " ${COMMANDS[@]} " =~ " ${fn} " ]]; then
     echo "${RED}Command not found: ${NC}"
-	echo "$fn"
-	if [ ! -z "$allParameters" -a "$allParameters" != " " ]; then
+    echo "$fn"
+
+    if [ ! -z "$allParameters" -a "$allParameters" != " " ]; then
         echo "${RED}\nParameters: ${NC}"
         echo "$allParameters"
-	fi
+    fi
 fi
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
Changed the default command to `"list"` to prevent the unhelpful 'Command not found' message. When running just the command `mac` the following output is generated:

```text
$ mac
Command not found: 

```

After commit 	767a2c1:

```text
$ mac
 mac CLI – OS X command line tools for developers
====================================================

General Utilities: 
mac update: Install OS X software updates, update installed Ruby gems, Homebrew, npm and their installed packages
mac lock: Lock
...
```

