### PR TITLE
Delete `brew` command not exists in plugin/brew

### DIFF
--- a/mac-cli/misc/help
+++ b/mac-cli/misc/help
@@ -130,7 +130,6 @@ case "$fn" in
 
 
     echo "\n\n${WHITEBOLD}Homebrew Utilities: "
-    echo "${LIGHTBLUE}mac brew${GRAY}: Get list of installed Homebrew packages "
     echo "${LIGHTBLUE}mac brew:update${GRAY}: Upgrade Homebrew, installed Homebrew packages, and cleanup "
 
 


### PR DESCRIPTION
Deleted `brew`command in base of this commit: https://github.com/guarinogabriel/Mac-CLI/commit/cb71bd39f2541117415a6f1cca3d2f6e0806d372#diff-a9ad7917d2b9ae2e9326e9bd8fca2188