### PR TITLE
Fix "umute" typo

### DIFF
--- a/mac-cli/plugins/volume
+++ b/mac-cli/plugins/volume
@@ -28,8 +28,8 @@ case "$fn" in
         echo "${WHITEBOLD}Mute:${NC} ${GREEN}true${NC}"
     ;;
 
-     # Umute volume
-    "volume:umute")
+     # Unmute volume
+    "volume:unmute")
         osascript -e "set volume output muted false"
         echo "${WHITEBOLD}Mute:${NC} ${GREEN}false${NC}"
     ;;


### PR DESCRIPTION
The commands list and the help refer to this command as unmute, not umute. the umute typo was introduced when the script was refactored. 
Example:
` cucumbur@cukebook ~ mac volume:umute  
Command not found:  
volume:umute  
Mute: false`
yet it will actually unmute the volume. volume:unmute, on the other hand, prints nothing and does nothing.