### PR TITLE
Remove --all from brew upgrade

### DIFF
--- a/mac-cli/plugins/brew
+++ b/mac-cli/plugins/brew
@@ -10,9 +10,9 @@ case "$fn" in
     "brew:update")
         echo "Updating Homebrew and its installed packages..."
         if [ "$echocommand" == "true" ]; then
-            echo "${GREEN}brew update; brew upgrade --all; brew cleanup; brew prune; brew cask cleanup;\n${NC}"
+            echo "${GREEN}brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;\n${NC}"
         fi
-        brew update; brew upgrade --all; brew cleanup; brew prune; brew cask cleanup;
+        brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;
     ;;
 
 esac

--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -23,9 +23,9 @@ case "$fn" in
 
         echo "Updating Homebrew and its installed packages..."
         if [ "$echocommand" == "true" ]; then
-            echo "${GREEN}brew update; brew upgrade --all; brew cleanup; brew prune; brew cask cleanup;\n${NC}"
+            echo "${GREEN}brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;\n${NC}"
         fi
-        brew update; brew upgrade --all; brew cleanup; brew prune; brew cask cleanup;
+        brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;
 
         echo "Updating npm and its installed packages..."
         if [ "$echocommand" == "true" ]; then


### PR DESCRIPTION
`brew upgrade --all` is equivalent to `brew upgrade` without any other
arguments. '--all' is no longer a valid argument. 