### PR TITLE
`brew upgrade` so `brew upgrade --all` is equivalent to `brew upgrade`

### DIFF
--- a/mac-cli/plugins/brew
+++ b/mac-cli/plugins/brew
@@ -10,9 +10,9 @@ case "$fn" in
     "brew:update")
         echo "Updating Homebrew and its installed packages..."
         if [ "$echocommand" == "true" ]; then
-            echo "${GREEN}brew update; brew upgrade --all; brew cleanup; brew prune; brew cask cleanup;\n${NC}"
+            echo "${GREEN}brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;\n${NC}"
         fi
-        brew update; brew upgrade --all; brew cleanup; brew prune; brew cask cleanup;
+        brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;
     ;;
 
 esac


### PR DESCRIPTION
-> removes the warning from brew:

Warning: We decided to not change the behaviour of `brew upgrade` so
`brew upgrade --all` is equivalent to `brew upgrade` without any other
arguments (so the `--all` is a no-op and can be removed).