### PR TITLE
Update install script to detect externally installed Node

### DIFF
--- a/mac-cli/tools/install
+++ b/mac-cli/tools/install
@@ -100,7 +100,7 @@ main() {
         brew install pv
 	fi
 
-    if [ ! -f /usr/local/bin/node ]; then
+    if ! which node > /dev/null; then
         echo "Installing node..."
         echo "${GREEN}brew install node\n${NC}"
         brew install node


### PR DESCRIPTION
The install script should check whether the `node` command exists instead of checking if the file exists at the default location. This prevents Node from being installed through `brew` when using an external version manager such as `nvm`.

On a side note, you may want to do this for the other executables as well.
