### PR TITLE
Corrected naming of command 'uninstall'

### DIFF
--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -83,7 +83,7 @@ case "$fn" in
 
 
     # Uninstall Mac CLI from your Mac
-    "upgrade")
+    "uninstall")
         if [ "$echocommand" == "true" ]; then
             echo "${GREEN}sh -c "$(curl -fsSL https://raw.githubusercontent.com/guarinogabriel/mac-cli/master/mac-cli/tools/uninstall)"\n\n${NC}"
         fi


### PR DESCRIPTION
Mistakenly labelled as 'upgrade'