### PR TITLE
Fixed eject-all osascript to be 'every disk whose ejectable is true'

### DIFF
--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -369,9 +369,9 @@ END
     # Eject all mounted volumes and disk
     "eject-all")
         if [ "$echocommand" == "true" ]; then
-            echo "${GREEN}osascript -e 'tell application 'Finder' to eject (every disk whose executable is true)'\n\n${NC}"
+            echo "${GREEN}osascript -e 'tell application 'Finder' to eject (every disk whose ejectable is true)'\n\n${NC}"
         fi
-        osascript -e 'tell application "Finder" to eject (every disk whose executable is true)'
+        osascript -e 'tell application "Finder" to eject (every disk whose ejectable is true)'
     ;;
 
 


### PR DESCRIPTION
Found this article online with the correct script wording, http://osxdaily.com/2014/05/22/eject-all-mounted-volumes-command-line-mac/. I ran it on OSX 10.11.6 El Capitan successfully.

This should close issue #119.