### PR TITLE
Remove duplicated menu entry

### DIFF
--- a/mac-cli/misc/help
+++ b/mac-cli/misc/help
@@ -164,7 +164,6 @@ function usageList()
             echo "${LIGHTBLUE}mac git:branch:remove-remote${GRAY}: Remove local and remote Git branch "
             echo "${LIGHTBLUE}mac git:remove${GRAY}: Remove Git from current project "
             echo "${LIGHTBLUE}mac git:branch${GRAY}: See all branches "
-            echo "${LIGHTBLUE}mac git:config${GRAY}: Check Git settings "
             echo "${LIGHTBLUE}mac git:add-removed${GRAY}: Add removed files to staged files "
             echo "${LIGHTBLUE}mac git:size${GRAY}: Get size for current Git repository "
             echo "${NC}\n"


### PR DESCRIPTION
Entries are duplicated:
mac git:config: Display local Git configuration                                                                                                                         
mac git:config: Check Git settings                                                                                                                                    

This PR removes the second one.