### PR TITLE
Fix starting screensaver on high sierra

### DIFF
--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -375,9 +375,9 @@ END
     # Start screensaver
     "screensaver")
         if [ "$echocommand" == "true" ]; then
-            echo "${GREEN}open -a /System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/ScreenSaverEngine.app\n\n${NC}"
+            echo "${GREEN}open -a ScreenSaverEngine\n\n${NC}"
         fi
-        open -a /System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/ScreenSaverEngine.app
+        open -a ScreenSaverEngine
     ;;
 
 


### PR DESCRIPTION
This should still work on older osx versions (not 100% sure tough).
If it doesn't i can make a version detection to it

Fixes #137 