### PR TITLE
Added --no-confirm to apm upgrade

### DIFF
--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -54,9 +54,9 @@ case "$fn" in
         if [ -f /usr/local/bin/apm ]; then
             echo "Updating Atom Packages..."
             if [ "$echocommand" == "true" ]; then
-                echo "${GREEN}apm upgrade\n${NC}"
+                echo "${GREEN}apm upgrade --no-confirm\n${NC}"
             fi
-            apm upgrade
+            apm upgrade --no-confirm
         fi
 
         if [ -f /usr/local/bin/n98-magerun.phar ]; then


### PR DESCRIPTION
This removes the need to type Y (or n) when upgrading apm packages.
For some more info on this can be found in https://github.com/atom/apm/issues/325