### PR TITLE
Removing `brew cask cleanup` step in `mac update`

### DIFF
--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -25,7 +25,7 @@ case "$fn" in
         if [ "$echocommand" == "true" ]; then
             echo "${GREEN}brew update; brew upgrade; brew cleanup; brew prune;\n${NC}"
         fi
-        brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;
+        brew update; brew upgrade; brew cleanup; brew prune;
 
         echo "Updating npm and its installed packages..."
         if [ "$echocommand" == "true" ]; then

--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -23,7 +23,7 @@ case "$fn" in
 
         echo "Updating Homebrew and its installed packages..."
         if [ "$echocommand" == "true" ]; then
-            echo "${GREEN}brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;\n${NC}"
+            echo "${GREEN}brew update; brew upgrade; brew cleanup; brew prune;\n${NC}"
         fi
         brew update; brew upgrade; brew cleanup; brew prune; brew cask cleanup;
 


### PR DESCRIPTION
Brew is giving out the following warning when running `mac update`:

```
Warning: Calling `brew cask cleanup` is deprecated and will be disabled on 2018-09-30! Use `brew cleanup` instead.
```

This change solves the warning.