### PR TITLE
fix correct time cmd

### DIFF
--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -202,7 +202,7 @@ END
 
 
     # Display clock in Terminal
-    "clock")
+    "time")
         if [ "$echocommand" == "true" ]; then
             echo "${GREEN}while sleep 1;do tput sc;tput cup 0 $(($(tput cols)-29));date;tput rc;done &'\n\n${NC}"
         fi


### PR DESCRIPTION
PR fixes wrong cmd name in the plugin from `clock` to correct `time`.

References: 
https://github.com/guarinogabriel/Mac-CLI/blob/master/mac#L84
https://github.com/guarinogabriel/Mac-CLI/blob/master/README.md#general-commands

Please let me know if it is supposed to be `clock` so I can change the above two files instead.