### PR TITLE
Fix `bluetooth:disable` & `bluetooth:enable` commands

### DIFF
--- a/mac-cli/plugins/general
+++ b/mac-cli/plugins/general
@@ -309,7 +309,7 @@ END
     "bluetooth:enable")
         echo "${GREEN}Bluetooth enabled{NC}"
         sudo defaults write /Library/Preferences/com.apple.Bluetooth ControllerPowerState -int 1 && \
-            sudo killall -HUP blued
+            sudo killall -HUP bluetoothd
     ;;
 
 
@@ -317,7 +317,7 @@ END
     "bluetooth:disable")
         echo "${GREEN}Bluetooth disabled${NC}"
         sudo defaults write /Library/Preferences/com.apple.Bluetooth ControllerPowerState -int 0 && \
-            sudo killall -HUP blued
+            sudo killall -HUP bluetoothd
     ;;
 
 


### PR DESCRIPTION
The daemon name blued (at least until macOS 10.11 El Capitan), has been changed to bluetoothd, source:
https://mogutan.wordpress.com/2018/07/24/switch-bluetooth-setting-from-command-line-on-macos/

Currently, running those commands on osx>10.11 will result in:
`No matching processes were found`